### PR TITLE
Fix: tng-cat only likes OSM descriptors with 'vendor' field.

### DIFF
--- a/packages/NSID1V_OSM/nsd.yaml
+++ b/packages/NSID1V_OSM/nsd.yaml
@@ -5,7 +5,7 @@ nsd:nsd-catalog:
         short-name: hackfest_basic-ns
         description: Simple NS with a single VNF and a single VL
         version: '1.0'
-        vendor: up
+        vendor: upb
         logo: osm.png
         constituent-vnfd:
         -   vnfd-id-ref: hackfest_basic-vnf

--- a/packages/NSID1V_OSM/nsd.yaml
+++ b/packages/NSID1V_OSM/nsd.yaml
@@ -5,6 +5,7 @@ nsd:nsd-catalog:
         short-name: hackfest_basic-ns
         description: Simple NS with a single VNF and a single VL
         version: '1.0'
+        vendor: up
         logo: osm.png
         constituent-vnfd:
         -   vnfd-id-ref: hackfest_basic-vnf

--- a/packages/NSID1V_OSM/vnfd1.yaml
+++ b/packages/NSID1V_OSM/vnfd1.yaml
@@ -4,6 +4,7 @@ vnfd:vnfd-catalog:
         name: hackfest_basic-vnf
         short-name: hackfest_basic-vnf
         version: '1.0'
+        vendor: upb
         description: A basic VNF descriptor w/ one VDU
         logo: osm.png
         connection-point:


### PR DESCRIPTION
Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>